### PR TITLE
feat: add isNameOnly metadata flag to search response

### DIFF
--- a/app/actions/search.ts
+++ b/app/actions/search.ts
@@ -1271,6 +1271,9 @@ export async function searchRenters(
       tips.push("Some matches need confirmation - add more identifiers");
     }
 
+    // Flag for name-only searches (no strong identifiers like phone/email/facebook)
+    const isNameOnly = !!nameNorm && !hasStrongInput && !searchInput.dateOfBirth;
+
     // If not authenticated, return only count and metadata, no actual results
     if (!isAuthenticated && results.length > 0) {
       return {
@@ -1281,6 +1284,7 @@ export async function searchRenters(
         meta: {
           searchTime: Date.now() - startTime,
           hasStrongInput,
+          isNameOnly,
           tips: tips.length > 0 ? tips : undefined,
           requiresAuth: true,
         },
@@ -1295,6 +1299,7 @@ export async function searchRenters(
       meta: {
         searchTime: Date.now() - startTime,
         hasStrongInput,
+        isNameOnly,
         tips: tips.length > 0 ? tips : undefined,
       },
     };

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -23,6 +23,7 @@ function SearchResultsContent() {
     const [searchMeta, setSearchMeta] = useState<{
         searchTime: number;
         hasStrongInput: boolean;
+        isNameOnly?: boolean;
         tips?: string[];
         requiresAuth?: boolean;
         totalCount?: number;

--- a/lib/matching/types.ts
+++ b/lib/matching/types.ts
@@ -145,6 +145,8 @@ export interface SearchResponse {
     searchTime: number;
     /** Whether any strong identifiers were in the query */
     hasStrongInput: boolean;
+    /** Whether the search was name-only (no phone/email/facebook/dob) */
+    isNameOnly?: boolean;
     /** Tips for improving search */
     tips?: string[];
     /** Whether authentication is required to see results */


### PR DESCRIPTION
Adds an `isNameOnly` flag to the search response metadata. This allows the UI to show a more informative warning when a user searches by name only (no phone/email/facebook/dob), encouraging them to add stronger identifiers for better accuracy. Also updates the `SearchResponse` type definition accordingly.