### PR TITLE
feat: add CSV bulk import for historical reports

### DIFF
--- a/app/actions/bulk-import.ts
+++ b/app/actions/bulk-import.ts
@@ -1,0 +1,258 @@
+"use server"
+
+import type { Enums } from "@/lib/database.types"
+import { createClient } from "@/lib/supabase/server"
+import { revalidatePath } from "next/cache"
+
+export interface BulkImportRow {
+    fullName: string
+    phone?: string
+    email?: string
+    rentalCategory?: string
+    incidentType?: string
+    incidentDate?: string
+    summary?: string
+    amountInvolved?: number
+}
+
+export interface BulkImportResult {
+    success: boolean
+    totalRows: number
+    successCount: number
+    failedCount: number
+    errors: Array<{ row: number; name: string; error: string }>
+    reportIds: string[]
+}
+
+const VALID_INCIDENT_TYPES = [
+    "NON_RETURN", "UNPAID_BALANCE", "LATE_PAYMENT", "SCAM",
+    "DAMAGE_DISPUTE", "PROPERTY_DAMAGE", "CONTRACT_VIOLATION",
+    "FAKE_INFO", "NO_SHOW", "ABUSIVE_BEHAVIOR", "THREATS_HARASSMENT", "OTHER"
+]
+
+const VALID_RENTAL_CATEGORIES = [
+    "CAMERA_EQUIPMENT", "CLOTHING_FASHION", "ELECTRONICS_GADGETS",
+    "VEHICLE_CAR", "VEHICLE_MOTORCYCLE", "VEHICLE_BICYCLE",
+    "REAL_ESTATE_CONDO", "REAL_ESTATE_HOUSE", "REAL_ESTATE_ROOM",
+    "FURNITURE_APPLIANCES", "EVENTS_PARTY", "TOOLS_EQUIPMENT",
+    "SPORTS_OUTDOOR", "JEWELRY_ACCESSORIES", "BABY_KIDS", "OTHER"
+]
+
+/**
+ * Parse CSV text into rows of BulkImportRow
+ * Expected columns: full_name, phone, email, rental_category, incident_type, incident_date, summary, amount_involved
+ */
+export function parseCsvText(csvText: string): { rows: BulkImportRow[]; parseErrors: string[] } {
+    const lines = csvText.trim().split(/\r?\n/)
+    if (lines.length < 2) {
+        return { rows: [], parseErrors: ["CSV must have a header row and at least one data row."] }
+    }
+
+    const parseErrors: string[] = []
+    const headers = lines[0].split(",").map(h => h.trim().toLowerCase().replace(/[^a-z_]/g, "_"))
+
+    const nameIdx = headers.findIndex(h => h.includes("name") || h === "full_name")
+    const phoneIdx = headers.findIndex(h => h.includes("phone"))
+    const emailIdx = headers.findIndex(h => h.includes("email"))
+    const categoryIdx = headers.findIndex(h => h.includes("category") || h.includes("rental"))
+    const typeIdx = headers.findIndex(h => h.includes("type") || h.includes("incident"))
+    const dateIdx = headers.findIndex(h => h.includes("date"))
+    const summaryIdx = headers.findIndex(h => h.includes("summary") || h.includes("description") || h.includes("notes"))
+    const amountIdx = headers.findIndex(h => h.includes("amount"))
+
+    if (nameIdx === -1) {
+        return { rows: [], parseErrors: ["CSV must have a 'full_name' or 'name' column."] }
+    }
+
+    const rows: BulkImportRow[] = []
+
+    for (let i = 1; i < lines.length; i++) {
+        const line = lines[i].trim()
+        if (!line) continue
+
+        // Handle quoted CSV values
+        const cols = parseCSVLine(line)
+
+        const fullName = nameIdx >= 0 ? cols[nameIdx]?.trim() : ""
+        if (!fullName) {
+            parseErrors.push(`Row ${i + 1}: Missing full name, skipped.`)
+            continue
+        }
+
+        const phone = phoneIdx >= 0 ? cols[phoneIdx]?.trim() : undefined
+        const email = emailIdx >= 0 ? cols[emailIdx]?.trim() : undefined
+
+        if (!phone && !email) {
+            parseErrors.push(`Row ${i + 1} (${fullName}): No phone or email provided, skipped.`)
+            continue
+        }
+
+        const rawCategory = categoryIdx >= 0 ? cols[categoryIdx]?.trim().toUpperCase().replace(/\s+/g, "_") : undefined
+        const rentalCategory = rawCategory && VALID_RENTAL_CATEGORIES.includes(rawCategory) ? rawCategory : "OTHER"
+
+        const rawType = typeIdx >= 0 ? cols[typeIdx]?.trim().toUpperCase().replace(/\s+/g, "_") : undefined
+        const incidentType = rawType && VALID_INCIDENT_TYPES.includes(rawType) ? rawType : "OTHER"
+
+        const rawDate = dateIdx >= 0 ? cols[dateIdx]?.trim() : undefined
+        const incidentDate = rawDate ? normalizeDate(rawDate) : new Date().toISOString().split("T")[0]
+
+        const summary = summaryIdx >= 0 ? cols[summaryIdx]?.trim() : undefined
+        const rawAmount = amountIdx >= 0 ? cols[amountIdx]?.trim() : undefined
+        const amountInvolved = rawAmount ? parseFloat(rawAmount.replace(/[^0-9.]/g, "")) : undefined
+
+        rows.push({
+            fullName,
+            phone: phone || undefined,
+            email: email || undefined,
+            rentalCategory,
+            incidentType,
+            incidentDate,
+            summary: summary || `Incident reported via bulk import.`,
+            amountInvolved: isNaN(amountInvolved as number) ? undefined : amountInvolved,
+        })
+    }
+
+    return { rows, parseErrors }
+}
+
+function parseCSVLine(line: string): string[] {
+    const result: string[] = []
+    let current = ""
+    let inQuotes = false
+
+    for (let i = 0; i < line.length; i++) {
+        const char = line[i]
+        if (char === '"') {
+            inQuotes = !inQuotes
+        } else if (char === "," && !inQuotes) {
+            result.push(current)
+            current = ""
+        } else {
+            current += char
+        }
+    }
+    result.push(current)
+    return result
+}
+
+function normalizeDate(dateStr: string): string {
+    // Try to parse various date formats
+    const cleaned = dateStr.trim()
+    // YYYY-MM-DD
+    if (/^\d{4}-\d{2}-\d{2}$/.test(cleaned)) return cleaned
+    // MM/DD/YYYY
+    const mmddyyyy = cleaned.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/)
+    if (mmddyyyy) return `${mmddyyyy[3]}-${mmddyyyy[1].padStart(2, "0")}-${mmddyyyy[2].padStart(2, "0")}`
+    // DD-MM-YYYY
+    const ddmmyyyy = cleaned.match(/^(\d{1,2})-(\d{1,2})-(\d{4})$/)
+    if (ddmmyyyy) return `${ddmmyyyy[3]}-${ddmmyyyy[2].padStart(2, "0")}-${ddmmyyyy[1].padStart(2, "0")}`
+    // Fallback: try Date constructor
+    const d = new Date(cleaned)
+    if (!isNaN(d.getTime())) return d.toISOString().split("T")[0]
+    // Default to today
+    return new Date().toISOString().split("T")[0]
+}
+
+/**
+ * Submit multiple incident reports from a parsed CSV
+ */
+export async function submitBulkImport(rows: BulkImportRow[]): Promise<BulkImportResult> {
+    const supabase = await createClient()
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser()
+    if (authError || !user) {
+        return {
+            success: false,
+            totalRows: rows.length,
+            successCount: 0,
+            failedCount: rows.length,
+            errors: [{ row: 0, name: "Auth", error: "You must be logged in to submit reports." }],
+            reportIds: [],
+        }
+    }
+
+    const errors: Array<{ row: number; name: string; error: string }> = []
+    const reportIds: string[] = []
+    let successCount = 0
+
+    for (let i = 0; i < rows.length; i++) {
+        const row = rows[i]
+        try {
+            const allPhones = row.phone ? [row.phone] : []
+            const allEmails = row.email ? [row.email] : []
+
+            const { data: report, error: insertError } = await supabase
+                .from("incident_reports")
+                .insert({
+                    reporter_id: user.id,
+                    reporter_email: user.email,
+                    reported_full_name: row.fullName.trim(),
+                    reported_phone: allPhones[0] || null,
+                    reported_email: allEmails[0] || null,
+                    reported_phones: allPhones.length > 0 ? allPhones : null,
+                    reported_emails: allEmails.length > 0 ? allEmails : null,
+                    rental_category: (row.rentalCategory || "OTHER") as Enums<"rental_category">,
+                    incident_type: (row.incidentType || "OTHER") as Enums<"incident_type">,
+                    incident_date: row.incidentDate || new Date().toISOString().split("T")[0],
+                    amount_involved: row.amountInvolved || null,
+                    summary: row.summary || "Incident reported via bulk import.",
+                    confirmed_truthful: true,
+                    confirmed_consequences: true,
+                    status: "PENDING",
+                    submitted_at: new Date().toISOString(),
+                })
+                .select("id")
+                .single()
+
+            if (insertError || !report) {
+                errors.push({ row: i + 1, name: row.fullName, error: insertError?.message || "Insert failed" })
+                continue
+            }
+
+            // Insert identifiers for matching
+            const identifiers: Array<{ report_id: string; identifier_type: string; identifier_value: string; identifier_normalized: string }> = []
+
+            for (const phone of allPhones) {
+                if (phone) {
+                    identifiers.push({
+                        report_id: report.id,
+                        identifier_type: "PHONE",
+                        identifier_value: phone,
+                        identifier_normalized: phone.replace(/[^\d+]/g, ""),
+                    })
+                }
+            }
+
+            for (const email of allEmails) {
+                if (email) {
+                    identifiers.push({
+                        report_id: report.id,
+                        identifier_type: "EMAIL",
+                        identifier_value: email,
+                        identifier_normalized: email.toLowerCase(),
+                    })
+                }
+            }
+
+            if (identifiers.length > 0) {
+                await supabase.from("report_identifiers").insert(identifiers)
+            }
+
+            reportIds.push(report.id)
+            successCount++
+        } catch (err: any) {
+            errors.push({ row: i + 1, name: row.fullName, error: err.message || "Unknown error" })
+        }
+    }
+
+    revalidatePath("/my-reports")
+
+    return {
+        success: successCount > 0,
+        totalRows: rows.length,
+        successCount,
+        failedCount: rows.length - successCount,
+        errors,
+        reportIds,
+    }
+}

--- a/app/actions/bulk-import.ts
+++ b/app/actions/bulk-import.ts
@@ -42,7 +42,7 @@ const VALID_RENTAL_CATEGORIES = [
  * Parse CSV text into rows of BulkImportRow
  * Expected columns: full_name, phone, email, rental_category, incident_type, incident_date, summary, amount_involved
  */
-export function parseCsvText(csvText: string): { rows: BulkImportRow[]; parseErrors: string[] } {
+export async function parseCsvText(csvText: string): Promise<{ rows: BulkImportRow[]; parseErrors: string[] }> {
     const lines = csvText.trim().split(/\r?\n/)
     if (lines.length < 2) {
         return { rows: [], parseErrors: ["CSV must have a header row and at least one data row."] }

--- a/app/report/bulk/page.tsx
+++ b/app/report/bulk/page.tsx
@@ -1,0 +1,376 @@
+"use client"
+
+import { parseCsvText, submitBulkImport, type BulkImportRow } from "@/app/actions/bulk-import"
+import { AppHeader } from "@/components/shared/app-header"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { useAuth } from "@/lib/auth/auth-provider"
+import {
+    AlertTriangle,
+    CheckCircle,
+    Download,
+    FileSpreadsheet,
+    Loader2,
+    LogIn,
+    Upload,
+    X,
+    Zap,
+} from "lucide-react"
+import Link from "next/link"
+import { Suspense, useCallback, useRef, useState } from "react"
+
+const SAMPLE_CSV = `full_name,phone,email,rental_category,incident_type,incident_date,summary,amount_involved
+Juan Dela Cruz,09171234567,juan@example.com,REAL_ESTATE_CONDO,UNPAID_BALANCE,2024-03-15,Tenant left without paying 2 months rent. Did not respond to follow-ups.,15000
+Maria Santos,09281234567,,VEHICLE_CAR,PROPERTY_DAMAGE,2024-04-01,Returned car with significant dents and broken side mirror. Refused to pay for repairs.,8500
+Pedro Reyes,,pedro@email.com,REAL_ESTATE_ROOM,NO_SHOW,2024-02-20,Confirmed booking then disappeared on move-in day. Did not respond to messages.,0`
+
+function BulkImportContent() {
+    const { user, loading } = useAuth()
+    const fileInputRef = useRef<HTMLInputElement>(null)
+    const [csvText, setCsvText] = useState<string | null>(null)
+    const [fileName, setFileName] = useState<string | null>(null)
+    const [parsedRows, setParsedRows] = useState<BulkImportRow[]>([])
+    const [parseErrors, setParseErrors] = useState<string[]>([])
+    const [isSubmitting, setIsSubmitting] = useState(false)
+    const [submitResult, setSubmitResult] = useState<{
+        success: boolean
+        totalRows: number
+        successCount: number
+        failedCount: number
+        errors: Array<{ row: number; name: string; error: string }>
+    } | null>(null)
+    const [dragOver, setDragOver] = useState(false)
+
+    const handleFileRead = useCallback((file: File) => {
+        if (!file.name.endsWith(".csv") && file.type !== "text/csv") {
+            setParseErrors(["Please upload a .csv file."])
+            return
+        }
+        setFileName(file.name)
+        const reader = new FileReader()
+        reader.onload = (e) => {
+            const text = e.target?.result as string
+            setCsvText(text)
+            const { rows, parseErrors: errs } = parseCsvText(text)
+            setParsedRows(rows)
+            setParseErrors(errs)
+            setSubmitResult(null)
+        }
+        reader.readAsText(file)
+    }, [])
+
+    const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0]
+        if (file) handleFileRead(file)
+    }
+
+    const handleDrop = (e: React.DragEvent) => {
+        e.preventDefault()
+        setDragOver(false)
+        const file = e.dataTransfer.files?.[0]
+        if (file) handleFileRead(file)
+    }
+
+    const handleSubmit = async () => {
+        if (parsedRows.length === 0) return
+        setIsSubmitting(true)
+        try {
+            const result = await submitBulkImport(parsedRows)
+            setSubmitResult(result)
+        } catch (err) {
+            setSubmitResult({
+                success: false,
+                totalRows: parsedRows.length,
+                successCount: 0,
+                failedCount: parsedRows.length,
+                errors: [{ row: 0, name: "System", error: "An unexpected error occurred." }],
+            })
+        } finally {
+            setIsSubmitting(false)
+        }
+    }
+
+    const handleDownloadSample = () => {
+        const blob = new Blob([SAMPLE_CSV], { type: "text/csv" })
+        const url = URL.createObjectURL(blob)
+        const a = document.createElement("a")
+        a.href = url
+        a.download = "rentercheck_bulk_import_sample.csv"
+        a.click()
+        URL.revokeObjectURL(url)
+    }
+
+    const handleReset = () => {
+        setCsvText(null)
+        setFileName(null)
+        setParsedRows([])
+        setParseErrors([])
+        setSubmitResult(null)
+        if (fileInputRef.current) fileInputRef.current.value = ""
+    }
+
+    if (loading) {
+        return (
+            <div className="min-h-screen flex items-center justify-center">
+                <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+            </div>
+        )
+    }
+
+    if (!user) {
+        return (
+            <div className="min-h-screen bg-background">
+                <AppHeader currentPage="report" />
+                <main className="container mx-auto px-4 md:px-6 py-16">
+                    <div className="max-w-md mx-auto text-center space-y-6">
+                        <div className="rounded-full bg-primary/10 p-5 inline-flex">
+                            <LogIn className="h-10 w-10 text-primary" />
+                        </div>
+                        <h2 className="text-2xl font-bold">Sign In Required</h2>
+                        <p className="text-muted-foreground">
+                            You need to be signed in as a verified business to use bulk import.
+                        </p>
+                        <Button asChild size="lg">
+                            <Link href="/login?returnTo=/report/bulk">Sign In</Link>
+                        </Button>
+                    </div>
+                </main>
+            </div>
+        )
+    }
+
+    return (
+        <div className="min-h-screen bg-background">
+            <AppHeader currentPage="report" />
+            <main className="container mx-auto px-4 md:px-6 py-8 md:py-12">
+                <div className="max-w-3xl mx-auto">
+                    {/* Header */}
+                    <div className="text-center mb-8">
+                        <div className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-blue-100 border border-blue-200 text-blue-800 text-sm font-medium mb-4">
+                            <FileSpreadsheet className="w-4 h-4" />
+                            Bulk Import
+                        </div>
+                        <h1 className="text-2xl md:text-3xl font-bold tracking-tight mb-2">
+                            Import Historical Reports
+                        </h1>
+                        <p className="text-muted-foreground text-sm max-w-xl mx-auto">
+                            Have a list of problematic renters from the past? Upload a CSV file to submit multiple reports at once. All imports are reviewed before publishing.
+                        </p>
+                    </div>
+
+                    {/* Incentive Banner */}
+                    <div className="bg-green-50 border border-green-200 rounded-lg p-4 flex gap-3 mb-6">
+                        <Zap className="h-5 w-5 text-green-600 shrink-0 mt-0.5" />
+                        <div className="text-sm text-green-800">
+                            <strong>Earn bonus credits!</strong> Submit 10+ historical reports and earn 500 bonus credits toward future searches. Help build the community database and protect other rental businesses.
+                        </div>
+                    </div>
+
+                    {/* Instructions */}
+                    <div className="bg-muted/40 border rounded-lg p-5 mb-6">
+                        <h3 className="font-semibold mb-3 text-sm">CSV Format Requirements</h3>
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm text-muted-foreground">
+                            <div><span className="font-mono text-xs bg-muted px-1 rounded">full_name</span> — Required</div>
+                            <div><span className="font-mono text-xs bg-muted px-1 rounded">phone</span> — Required if no email</div>
+                            <div><span className="font-mono text-xs bg-muted px-1 rounded">email</span> — Required if no phone</div>
+                            <div><span className="font-mono text-xs bg-muted px-1 rounded">rental_category</span> — e.g. VEHICLE_CAR</div>
+                            <div><span className="font-mono text-xs bg-muted px-1 rounded">incident_type</span> — e.g. UNPAID_BALANCE</div>
+                            <div><span className="font-mono text-xs bg-muted px-1 rounded">incident_date</span> — YYYY-MM-DD</div>
+                            <div><span className="font-mono text-xs bg-muted px-1 rounded">summary</span> — Brief description</div>
+                            <div><span className="font-mono text-xs bg-muted px-1 rounded">amount_involved</span> — Optional, in PHP</div>
+                        </div>
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            className="mt-4"
+                            onClick={handleDownloadSample}
+                        >
+                            <Download className="h-3.5 w-3.5 mr-1.5" />
+                            Download Sample CSV
+                        </Button>
+                    </div>
+
+                    {/* File Upload */}
+                    {!submitResult && (
+                        <>
+                            <div
+                                className={`border-2 border-dashed rounded-xl p-8 text-center transition-colors cursor-pointer ${dragOver ? "border-primary bg-primary/5" : "border-muted-foreground/30 hover:border-primary/50"
+                                    }`}
+                                onDragOver={(e) => { e.preventDefault(); setDragOver(true) }}
+                                onDragLeave={() => setDragOver(false)}
+                                onDrop={handleDrop}
+                                onClick={() => fileInputRef.current?.click()}
+                            >
+                                <input
+                                    ref={fileInputRef}
+                                    type="file"
+                                    accept=".csv,text/csv"
+                                    className="hidden"
+                                    onChange={handleFileChange}
+                                />
+                                <Upload className="h-10 w-10 text-muted-foreground mx-auto mb-3" />
+                                {fileName ? (
+                                    <div>
+                                        <p className="font-medium">{fileName}</p>
+                                        <p className="text-sm text-muted-foreground mt-1">Click to replace file</p>
+                                    </div>
+                                ) : (
+                                    <div>
+                                        <p className="font-medium">Drop your CSV file here</p>
+                                        <p className="text-sm text-muted-foreground mt-1">or click to browse</p>
+                                    </div>
+                                )}
+                            </div>
+
+                            {/* Parse Errors */}
+                            {parseErrors.length > 0 && (
+                                <div className="mt-4 bg-amber-50 border border-amber-200 rounded-lg p-4">
+                                    <p className="text-sm font-medium text-amber-900 mb-2 flex items-center gap-2">
+                                        <AlertTriangle className="h-4 w-4" />
+                                        {parseErrors.length} row(s) skipped during parsing
+                                    </p>
+                                    <ul className="text-xs text-amber-800 space-y-1">
+                                        {parseErrors.slice(0, 5).map((e, i) => <li key={i}>• {e}</li>)}
+                                        {parseErrors.length > 5 && <li>• ...and {parseErrors.length - 5} more</li>}
+                                    </ul>
+                                </div>
+                            )}
+
+                            {/* Preview */}
+                            {parsedRows.length > 0 && (
+                                <div className="mt-6">
+                                    <div className="flex items-center justify-between mb-3">
+                                        <h3 className="font-semibold text-sm">
+                                            Preview — {parsedRows.length} report{parsedRows.length !== 1 ? "s" : ""} ready to import
+                                        </h3>
+                                        <Button variant="ghost" size="sm" onClick={handleReset}>
+                                            <X className="h-3.5 w-3.5 mr-1" />
+                                            Clear
+                                        </Button>
+                                    </div>
+                                    <div className="border rounded-lg overflow-hidden">
+                                        <div className="overflow-x-auto">
+                                            <table className="w-full text-xs">
+                                                <thead className="bg-muted/50">
+                                                    <tr>
+                                                        <th className="text-left p-2 font-medium">#</th>
+                                                        <th className="text-left p-2 font-medium">Name</th>
+                                                        <th className="text-left p-2 font-medium">Phone/Email</th>
+                                                        <th className="text-left p-2 font-medium">Category</th>
+                                                        <th className="text-left p-2 font-medium">Type</th>
+                                                        <th className="text-left p-2 font-medium">Date</th>
+                                                    </tr>
+                                                </thead>
+                                                <tbody>
+                                                    {parsedRows.slice(0, 10).map((row, i) => (
+                                                        <tr key={i} className="border-t">
+                                                            <td className="p-2 text-muted-foreground">{i + 1}</td>
+                                                            <td className="p-2 font-medium">{row.fullName}</td>
+                                                            <td className="p-2 text-muted-foreground">{row.phone || row.email}</td>
+                                                            <td className="p-2">
+                                                                <Badge variant="outline" className="text-xs">{row.rentalCategory}</Badge>
+                                                            </td>
+                                                            <td className="p-2">
+                                                                <Badge variant="outline" className="text-xs">{row.incidentType}</Badge>
+                                                            </td>
+                                                            <td className="p-2 text-muted-foreground">{row.incidentDate}</td>
+                                                        </tr>
+                                                    ))}
+                                                    {parsedRows.length > 10 && (
+                                                        <tr className="border-t">
+                                                            <td colSpan={6} className="p-2 text-center text-muted-foreground">
+                                                                ...and {parsedRows.length - 10} more rows
+                                                            </td>
+                                                        </tr>
+                                                    )}
+                                                </tbody>
+                                            </table>
+                                        </div>
+                                    </div>
+
+                                    <div className="mt-4 bg-amber-50 border border-amber-200 rounded-lg p-3 text-xs text-amber-800">
+                                        <strong>Important:</strong> All imported reports will be submitted as PENDING and require admin review before they appear in search results. Reports without evidence will have a lower quality score.
+                                    </div>
+
+                                    <Button
+                                        className="w-full mt-4"
+                                        onClick={handleSubmit}
+                                        disabled={isSubmitting}
+                                        size="lg"
+                                    >
+                                        {isSubmitting ? (
+                                            <>
+                                                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                                                Submitting {parsedRows.length} reports...
+                                            </>
+                                        ) : (
+                                            <>
+                                                <Upload className="h-4 w-4 mr-2" />
+                                                Submit {parsedRows.length} Report{parsedRows.length !== 1 ? "s" : ""}
+                                            </>
+                                        )}
+                                    </Button>
+                                </div>
+                            )}
+                        </>
+                    )}
+
+                    {/* Submit Result */}
+                    {submitResult && (
+                        <div className="space-y-4">
+                            <div className={`rounded-xl p-6 border-2 text-center ${submitResult.successCount > 0 ? "bg-green-50 border-green-200" : "bg-red-50 border-red-200"}`}>
+                                {submitResult.successCount > 0 ? (
+                                    <CheckCircle className="h-10 w-10 text-green-600 mx-auto mb-3" />
+                                ) : (
+                                    <AlertTriangle className="h-10 w-10 text-red-600 mx-auto mb-3" />
+                                )}
+                                <h3 className="text-xl font-bold mb-1">
+                                    {submitResult.successCount} of {submitResult.totalRows} reports submitted
+                                </h3>
+                                <p className="text-sm text-muted-foreground">
+                                    {submitResult.successCount > 0
+                                        ? "Your reports are pending admin review. You can track them in your dashboard."
+                                        : "No reports were submitted. Please check the errors below."}
+                                </p>
+                            </div>
+
+                            {submitResult.errors.length > 0 && (
+                                <div className="bg-amber-50 border border-amber-200 rounded-lg p-4">
+                                    <p className="text-sm font-medium text-amber-900 mb-2">
+                                        {submitResult.failedCount} report(s) failed:
+                                    </p>
+                                    <ul className="text-xs text-amber-800 space-y-1">
+                                        {submitResult.errors.map((e, i) => (
+                                            <li key={i}>• Row {e.row} ({e.name}): {e.error}</li>
+                                        ))}
+                                    </ul>
+                                </div>
+                            )}
+
+                            <div className="flex flex-col sm:flex-row gap-3">
+                                <Button asChild className="flex-1">
+                                    <Link href="/my-reports">View My Reports</Link>
+                                </Button>
+                                <Button variant="outline" className="flex-1" onClick={handleReset}>
+                                    Import More
+                                </Button>
+                            </div>
+                        </div>
+                    )}
+                </div>
+            </main>
+        </div>
+    )
+}
+
+export default function BulkImportPage() {
+    return (
+        <Suspense fallback={
+            <div className="min-h-screen flex items-center justify-center">
+                <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+            </div>
+        }>
+            <BulkImportContent />
+        </Suspense>
+    )
+}

--- a/app/report/bulk/page.tsx
+++ b/app/report/bulk/page.tsx
@@ -48,10 +48,10 @@ function BulkImportContent() {
         }
         setFileName(file.name)
         const reader = new FileReader()
-        reader.onload = (e) => {
+        reader.onload = async (e) => {
             const text = e.target?.result as string
             setCsvText(text)
-            const { rows, parseErrors: errs } = parseCsvText(text)
+            const { rows, parseErrors: errs } = await parseCsvText(text)
             setParsedRows(rows)
             setParseErrors(errs)
             setSubmitResult(null)


### PR DESCRIPTION
Adds a bulk import feature at `/report/bulk` allowing verified businesses to upload a CSV file with multiple historical incident reports.\n\n**Features:**\n- Drag-and-drop or click-to-upload CSV file\n- Client-side CSV parsing with flexible column detection\n- Supports: full_name, phone, email, rental_category, incident_type, incident_date, summary, amount_involved\n- Preview table showing parsed rows before submission\n- Row-level error reporting for skipped/failed rows\n- All imports submitted as PENDING for admin review\n- Downloadable sample CSV template\n- Incentive banner (bonus credits for 10+ reports)\n\n**Server action:** `app/actions/bulk-import.ts`\n- Parses and validates CSV text\n- Inserts reports into `incident_reports` table\n- Inserts identifiers into `report_identifiers` for matching