### PR TITLE
feat: add search filters panel (rental category, incident type, date range)

### DIFF
--- a/app/actions/search.ts
+++ b/app/actions/search.ts
@@ -1258,29 +1258,53 @@ export async function searchRenters(
       };
     });
 
+    // Apply optional post-scoring filters (rental category, incident type, date range)
+    let filteredResults = results;
+    if (filters.rentalCategory || filters.incidentType || filters.dateFrom || filters.dateTo) {
+      filteredResults = results.filter((r) => {
+        const summaries = r.renter.incidentSummaries;
+        if (!summaries || summaries.length === 0) {
+          // For renters without incident summaries in results, we can't filter by category/type/date
+          // Keep them unless we have strict filters — they may have matching incidents not in the summary
+          return true;
+        }
+        return summaries.some((s) => {
+          if (filters.rentalCategory && s.category !== filters.rentalCategory) return false;
+          if (filters.incidentType && s.type !== filters.incidentType) return false;
+          if (filters.dateFrom && s.date < filters.dateFrom) return false;
+          if (filters.dateTo && s.date > filters.dateTo) return false;
+          return true;
+        });
+      });
+    }
+
     // Generate tips based on search
     const tips: string[] = [];
-    if (!hasStrongInput && results.length > 0) {
+    if (!hasStrongInput && filteredResults.length > 0) {
       tips.push("Add phone number or email for more accurate matching");
     }
-    if (results.length === 0 && nameNorm) {
+    if (filteredResults.length === 0 && nameNorm) {
       tips.push("Try searching with the exact phone number or email");
       tips.push("Check the spelling of the name");
     }
-    if (results.some((r) => r.requiresConfirmation)) {
+    if (filteredResults.some((r) => r.requiresConfirmation)) {
       tips.push("Some matches need confirmation - add more identifiers");
     }
 
+    // Flag for name-only searches (no strong identifiers like phone/email/facebook)
+    const isNameOnly = !!nameNorm && !hasStrongInput && !searchInput.dateOfBirth;
+
     // If not authenticated, return only count and metadata, no actual results
-    if (!isAuthenticated && results.length > 0) {
+    if (!isAuthenticated && filteredResults.length > 0) {
       return {
         success: true,
         results: [],
-        totalCount: results.length,
+        totalCount: filteredResults.length,
         query: originalQuery,
         meta: {
           searchTime: Date.now() - startTime,
           hasStrongInput,
+          isNameOnly,
           tips: tips.length > 0 ? tips : undefined,
           requiresAuth: true,
         },
@@ -1289,12 +1313,13 @@ export async function searchRenters(
 
     return {
       success: true,
-      results,
-      totalCount: results.length,
+      results: filteredResults,
+      totalCount: filteredResults.length,
       query: originalQuery,
       meta: {
         searchTime: Date.now() - startTime,
         hasStrongInput,
+        isNameOnly,
         tips: tips.length > 0 ? tips : undefined,
       },
     };

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -3,12 +3,13 @@
 import { searchRenters } from "@/app/actions/search";
 import { ImproveAccuracyCard } from "@/components/search-results/improve-accuracy-card";
 import { ResultCard } from "@/components/search-results/result-card";
+import { SearchFiltersPanel, type SearchFilterValues } from "@/components/search-results/search-filters-panel";
 import { AppHeader } from "@/components/shared/app-header";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { SearchResultMatch } from "@/lib/types";
-import { AlertTriangle, FileWarning, Info, Lightbulb, Loader2, Lock, LogIn, SearchX, Shield } from "lucide-react";
+import { AlertTriangle, FileWarning, Info, Lightbulb, Loader2, Lock, LogIn, Shield } from "lucide-react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useEffect, useState, useTransition } from "react";
@@ -23,12 +24,14 @@ function SearchResultsContent() {
     const [searchMeta, setSearchMeta] = useState<{
         searchTime: number;
         hasStrongInput: boolean;
+        isNameOnly?: boolean;
         tips?: string[];
         requiresAuth?: boolean;
         totalCount?: number;
     } | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [isPending, startTransition] = useTransition();
+    const [filters, setFilters] = useState<SearchFilterValues>({});
 
     const handleSearch = (newQuery: string) => {
         router.push(`/search?q=${encodeURIComponent(newQuery)}`);
@@ -46,7 +49,12 @@ function SearchResultsContent() {
 
         startTransition(async () => {
             try {
-                const response = await searchRenters(query);
+                const response = await searchRenters(query, {
+                    rentalCategory: filters.rentalCategory,
+                    incidentType: filters.incidentType,
+                    dateFrom: filters.dateFrom,
+                    dateTo: filters.dateTo,
+                });
 
                 if (response.success) {
                     setResults(response.results);
@@ -64,7 +72,7 @@ function SearchResultsContent() {
                 setSearchCount(prev => prev + 1);
             }
         });
-    }, [query]);
+    }, [query, filters]);
 
     // Group results by confidence level
     const confirmedMatches = results.filter(r => r.confidence === 'CONFIRMED' || r.confidence === 'HIGH');
@@ -104,6 +112,11 @@ function SearchResultsContent() {
 
                         <Separator />
 
+                        {/* Filters Panel - shown when there's a query */}
+                        {query && (
+                            <SearchFiltersPanel filters={filters} onChange={setFilters} />
+                        )}
+
                         {/* Multi-input Search Tip - shown when no query */}
                         {!query && (
                             <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 flex gap-3">
@@ -122,7 +135,7 @@ function SearchResultsContent() {
                         )}
 
                         {/* Search Tips Banner */}
-                        {searchMeta && !searchMeta.hasStrongInput && results.length > 0 && (
+                        {searchMeta?.isNameOnly && results.length > 0 && (
                             <div className="bg-amber-50 border border-amber-200 rounded-lg p-4 flex gap-3">
                                 <AlertTriangle className="h-5 w-5 text-amber-600 shrink-0 mt-0.5" />
                                 <div className="space-y-1">
@@ -156,7 +169,6 @@ function SearchResultsContent() {
                             </div>
                         ) : searchMeta?.requiresAuth ? (
                             // Non-authenticated user - backend returned requiresAuth flag
-                            // Show clean sign-in prompt without any data
                             <div className="flex flex-col items-center justify-center">
                                 <div className=" w-full">
                                     <div className="bg-card border-2 border-primary/20 rounded-xl p-8 md:p-10 shadow-xl text-center space-y-6">
@@ -276,7 +288,7 @@ function SearchResultsContent() {
                                     <li>• Searching with phone number or email instead</li>
                                     <li>• Using the Facebook profile URL</li>
                                 </ul>
-                                
+
                                 {/* Call to Action */}
                                 <div className="mt-6 p-4 md:p-6 bg-background border rounded-lg max-w-md w-full mx-4">
                                     <div className="flex items-start gap-3 mb-3">

--- a/components/search-results/search-filters-panel.tsx
+++ b/components/search-results/search-filters-panel.tsx
@@ -90,14 +90,14 @@ export function SearchFiltersPanel({ filters, onChange }: SearchFiltersPanelProp
                         <div className="space-y-1.5">
                             <Label className="text-xs text-muted-foreground uppercase tracking-wider">Rental Category</Label>
                             <Select
-                                value={filters.rentalCategory || ""}
-                                onValueChange={(v) => onChange({ ...filters, rentalCategory: v || undefined })}
+                                value={filters.rentalCategory || "all"}
+                                onValueChange={(v) => onChange({ ...filters, rentalCategory: v === "all" ? undefined : v })}
                             >
                                 <SelectTrigger className="h-9 text-sm">
                                     <SelectValue placeholder="All categories" />
                                 </SelectTrigger>
                                 <SelectContent>
-                                    <SelectItem value="">All categories</SelectItem>
+                                    <SelectItem value="all">All categories</SelectItem>
                                     {RENTAL_CATEGORIES.map((cat) => (
                                         <SelectItem key={cat.value} value={cat.value}>{cat.label}</SelectItem>
                                     ))}
@@ -109,14 +109,14 @@ export function SearchFiltersPanel({ filters, onChange }: SearchFiltersPanelProp
                         <div className="space-y-1.5">
                             <Label className="text-xs text-muted-foreground uppercase tracking-wider">Incident Type</Label>
                             <Select
-                                value={filters.incidentType || ""}
-                                onValueChange={(v) => onChange({ ...filters, incidentType: v || undefined })}
+                                value={filters.incidentType || "all"}
+                                onValueChange={(v) => onChange({ ...filters, incidentType: v === "all" ? undefined : v })}
                             >
                                 <SelectTrigger className="h-9 text-sm">
                                     <SelectValue placeholder="All incident types" />
                                 </SelectTrigger>
                                 <SelectContent>
-                                    <SelectItem value="">All incident types</SelectItem>
+                                    <SelectItem value="all">All incident types</SelectItem>
                                     {INCIDENT_TYPES.map((type) => (
                                         <SelectItem key={type.value} value={type.value}>{type.label}</SelectItem>
                                     ))}

--- a/components/search-results/search-filters-panel.tsx
+++ b/components/search-results/search-filters-panel.tsx
@@ -1,0 +1,168 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Input } from "@/components/ui/input"
+import { SlidersHorizontal, X } from "lucide-react"
+import { useState } from "react"
+
+const INCIDENT_TYPES = [
+    { value: "NON_RETURN", label: "Non-return of item/unit" },
+    { value: "UNPAID_BALANCE", label: "Unpaid balance" },
+    { value: "LATE_PAYMENT", label: "Consistently late payments" },
+    { value: "SCAM", label: "Scam / Fraudulent transaction" },
+    { value: "DAMAGE_DISPUTE", label: "Damage to item/property" },
+    { value: "PROPERTY_DAMAGE", label: "Intentional property damage" },
+    { value: "CONTRACT_VIOLATION", label: "Violated rental agreement" },
+    { value: "FAKE_INFO", label: "Fake info / Identity mismatch" },
+    { value: "NO_SHOW", label: "No-show / Ghosting" },
+    { value: "ABUSIVE_BEHAVIOR", label: "Rude / Abusive behavior" },
+    { value: "THREATS_HARASSMENT", label: "Threats / Harassment" },
+    { value: "OTHER", label: "Other issue" },
+]
+
+const RENTAL_CATEGORIES = [
+    { value: "CAMERA_EQUIPMENT", label: "Camera & Photography" },
+    { value: "CLOTHING_FASHION", label: "Clothing & Fashion" },
+    { value: "ELECTRONICS_GADGETS", label: "Electronics & Gadgets" },
+    { value: "VEHICLE_CAR", label: "Car" },
+    { value: "VEHICLE_MOTORCYCLE", label: "Motorcycle" },
+    { value: "VEHICLE_BICYCLE", label: "Bicycle / E-bike" },
+    { value: "REAL_ESTATE_CONDO", label: "Condo / Apartment" },
+    { value: "REAL_ESTATE_HOUSE", label: "House" },
+    { value: "REAL_ESTATE_ROOM", label: "Room / Bedspace" },
+    { value: "FURNITURE_APPLIANCES", label: "Furniture & Appliances" },
+    { value: "EVENTS_PARTY", label: "Events & Party" },
+    { value: "TOOLS_EQUIPMENT", label: "Tools & Equipment" },
+    { value: "SPORTS_OUTDOOR", label: "Sports & Outdoor" },
+    { value: "JEWELRY_ACCESSORIES", label: "Jewelry & Accessories" },
+    { value: "BABY_KIDS", label: "Baby & Kids" },
+    { value: "OTHER", label: "Other" },
+]
+
+export interface SearchFilterValues {
+    rentalCategory?: string
+    incidentType?: string
+    dateFrom?: string
+    dateTo?: string
+}
+
+interface SearchFiltersPanelProps {
+    filters: SearchFilterValues
+    onChange: (filters: SearchFilterValues) => void
+}
+
+export function SearchFiltersPanel({ filters, onChange }: SearchFiltersPanelProps) {
+    const [isExpanded, setIsExpanded] = useState(false)
+
+    const hasActiveFilters = !!(filters.rentalCategory || filters.incidentType || filters.dateFrom || filters.dateTo)
+
+    const handleClear = () => {
+        onChange({ rentalCategory: undefined, incidentType: undefined, dateFrom: undefined, dateTo: undefined })
+    }
+
+    return (
+        <div className="border rounded-lg bg-background shadow-sm">
+            {/* Toggle Header */}
+            <button
+                type="button"
+                className="w-full flex items-center justify-between p-4 text-left"
+                onClick={() => setIsExpanded(!isExpanded)}
+            >
+                <div className="flex items-center gap-2">
+                    <SlidersHorizontal className="h-4 w-4 text-muted-foreground" />
+                    <span className="text-sm font-medium">Filter Results</span>
+                    {hasActiveFilters && (
+                        <span className="inline-flex items-center justify-center h-5 min-w-5 px-1.5 rounded-full bg-primary text-primary-foreground text-xs font-medium">
+                            {[filters.rentalCategory, filters.incidentType, filters.dateFrom, filters.dateTo].filter(Boolean).length}
+                        </span>
+                    )}
+                </div>
+                <span className="text-xs text-muted-foreground">{isExpanded ? "Hide" : "Show"}</span>
+            </button>
+
+            {/* Filter Fields */}
+            {isExpanded && (
+                <div className="px-4 pb-4 border-t pt-4 space-y-4">
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                        {/* Rental Category */}
+                        <div className="space-y-1.5">
+                            <Label className="text-xs text-muted-foreground uppercase tracking-wider">Rental Category</Label>
+                            <Select
+                                value={filters.rentalCategory || ""}
+                                onValueChange={(v) => onChange({ ...filters, rentalCategory: v || undefined })}
+                            >
+                                <SelectTrigger className="h-9 text-sm">
+                                    <SelectValue placeholder="All categories" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    <SelectItem value="">All categories</SelectItem>
+                                    {RENTAL_CATEGORIES.map((cat) => (
+                                        <SelectItem key={cat.value} value={cat.value}>{cat.label}</SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
+                        </div>
+
+                        {/* Incident Type */}
+                        <div className="space-y-1.5">
+                            <Label className="text-xs text-muted-foreground uppercase tracking-wider">Incident Type</Label>
+                            <Select
+                                value={filters.incidentType || ""}
+                                onValueChange={(v) => onChange({ ...filters, incidentType: v || undefined })}
+                            >
+                                <SelectTrigger className="h-9 text-sm">
+                                    <SelectValue placeholder="All incident types" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    <SelectItem value="">All incident types</SelectItem>
+                                    {INCIDENT_TYPES.map((type) => (
+                                        <SelectItem key={type.value} value={type.value}>{type.label}</SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
+                        </div>
+
+                        {/* Date From */}
+                        <div className="space-y-1.5">
+                            <Label className="text-xs text-muted-foreground uppercase tracking-wider">Incident Date From</Label>
+                            <Input
+                                type="date"
+                                className="h-9 text-sm"
+                                value={filters.dateFrom || ""}
+                                max={filters.dateTo || new Date().toISOString().split("T")[0]}
+                                onChange={(e) => onChange({ ...filters, dateFrom: e.target.value || undefined })}
+                            />
+                        </div>
+
+                        {/* Date To */}
+                        <div className="space-y-1.5">
+                            <Label className="text-xs text-muted-foreground uppercase tracking-wider">Incident Date To</Label>
+                            <Input
+                                type="date"
+                                className="h-9 text-sm"
+                                value={filters.dateTo || ""}
+                                min={filters.dateFrom}
+                                max={new Date().toISOString().split("T")[0]}
+                                onChange={(e) => onChange({ ...filters, dateTo: e.target.value || undefined })}
+                            />
+                        </div>
+                    </div>
+
+                    {hasActiveFilters && (
+                        <Button
+                            variant="ghost"
+                            size="sm"
+                            className="text-muted-foreground hover:text-foreground"
+                            onClick={handleClear}
+                        >
+                            <X className="h-3.5 w-3.5 mr-1.5" />
+                            Clear all filters
+                        </Button>
+                    )}
+                </div>
+            )}
+        </div>
+    )
+}

--- a/lib/matching/types.ts
+++ b/lib/matching/types.ts
@@ -48,6 +48,14 @@ export interface SearchFilters {
   requireStrongMatch?: boolean;
   /** Include unverified renters */
   includeUnverified?: boolean;
+  /** Filter by rental category (e.g. VEHICLE_CAR, REAL_ESTATE_CONDO) */
+  rentalCategory?: string;
+  /** Filter by incident type (e.g. UNPAID_BALANCE, PROPERTY_DAMAGE) */
+  incidentType?: string;
+  /** Filter incidents from this date (ISO string YYYY-MM-DD) */
+  dateFrom?: string;
+  /** Filter incidents up to this date (ISO string YYYY-MM-DD) */
+  dateTo?: string;
 }
 
 // ============================================


### PR DESCRIPTION
Adds a collapsible filter panel to the search results page, allowing users to narrow down results by:\n\n- **Rental Category** (e.g. Car, Condo, Camera Equipment)\n- **Incident Type** (e.g. Unpaid Balance, Property Damage)\n- **Incident Date From / To** (date range filter)\n\nFilters are applied post-scoring on the server side via the `SearchFilters` interface. The filter panel shows an active filter count badge when filters are applied, and has a 'Clear all' button.\n\nAlso updates the `SearchFilters` type in `lib/matching/types.ts` to include the new filter fields, and updates the `searchRenters` action to apply them.