### PR TITLE
fix: exclude playwright config and tests from TypeScript compilation

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "playwright.config.ts", "tests/**"]
 }


### PR DESCRIPTION
## Problem
Vercel deployment was failing with:
```
Type error: Cannot find module '@playwright/test' or its corresponding type declarations.
```

The `playwright.config.ts` was being included in the Next.js TypeScript compilation, but `@playwright/test` is a dev dependency not available in the Vercel build environment.

## Fix
Added `playwright.config.ts` and `tests/**` to the `exclude` array in `tsconfig.json` so they are not compiled as part of the Next.js build.